### PR TITLE
[CI/CD] GitHub Actions CI 파이프라인 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,17 +7,20 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'GomSon-E/robot-studio'
     permissions:
       contents: read
       packages: write
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set lowercase image prefix
+        run: echo "IMAGE_PREFIX=ghcr.io/gomson-e" >> $GITHUB_ENV
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,42 @@
+name: CI/CD Pipeline
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build server image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.IMAGE_PREFIX }}/robot-studio-server:latest
+
+      - name: Build web image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./web
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.IMAGE_PREFIX }}/robot-studio-web:latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary (한 줄 요약)
- main 브랜치에 push될 때 server/web Docker 이미지를 빌드하고 GHCR에 자동 push하는 CI 워크플로우 추가

## Background / Why (배경)
- Docker 이미지를 수동으로 빌드·푸시하는 반복 작업 자동화 필요
- Docker 이미지를 Registry에 보과내 배포 파이프라인 기반 마련

## What Changed (변경 내용)

### 추가
- `.github/workflows/cicd.yml` - GitHub Actions CI 워크플로우 신규 추가
  - `push` to `main`, `workflow_dispatch` 트리거
  - `server` 이미지 빌드 및 `ghcr.io/gomson-e/robot-studio-server:latest`로 push
  - `web` 이미지 빌드 및 `ghcr.io/gomson-e/robot-studio-web:latest`로 push
  - `GITHUB_TOKEN`을 사용한 GHCR 인증

## Design / Considerations (설계 & 고민한 점)
- **포크 저장소 제한**: `if: github.repository == 'GomSon-E/robot-studio'` 조건으로 포크에서 워크플로우가 실행되어도 빌드 잡 자체가 skip됨. secrets 노출 없이 포크 기여자의 불필요한 실행 방지
- **push 조건 방어 코드**: `push: ${{ github.event_name != 'pull_request' }}`는 현재 트리거(`push`, `workflow_dispatch`)에서는 항상 `true`로 실제 동작에 영향 없음. 향후 `pull_request` 트리거를 추가할 경우 이미지가 불필요하게 push되는 것을 막는 방어 코드

## How to Test (테스트 방법)
1. upstream main에 머지 및 origin main에서 sync fork 후 Actions 탭에서 build job 성공 확인
2. GitHub Packages(`https://github.com/orgs/GomSon-E/packages`)에서 `robot-studio-server`, `robot-studio-web` 이미지 push 확인

### 사전 검증
아직 AWS EC2 미구성 상태로, 개발 중 upstream main에 직접 push한 후, GHCR에서 이미지 pull 및 로컬 postgres와 연결해 서버 정상 동작 확인 완료

## Impact / Risk (영향도 & 리스크)
- 기존 코드 변경 없음, 워크플로우 파일만 추가
- main push마다 Docker 빌드가 실행되므로 Actions 사용량 증가

## Development Notes
- [[DevOps] CI/CD와 GitHub Actions: 배포 자동화의 시작](https://gomson-e.tistory.com/entry/CICD%EC%99%80-GitHub-Actions-%EB%B0%B0%ED%8F%AC-%EC%9E%90%EB%8F%99%ED%99%94%EC%9D%98-%EC%8B%9C%EC%9E%91)

## Questions / Feedback Needed (리뷰 요청 포인트)
- 현재 `server`와 `web` 빌드가 순차 step으로 실행되는데, 병렬 job으로 분리할지